### PR TITLE
feat: filter accepts any truthy predicate return value

### DIFF
--- a/iterpy/arr.py
+++ b/iterpy/arr.py
@@ -98,7 +98,7 @@ class Arr(Generic[T], Sequence[T]):
         """
         return self.lazy().pmap(func).collect()
 
-    def filter(self, func: Callable[[T], bool]) -> Arr[T]:
+    def filter(self, func: Callable[[T], object]) -> Arr[T]:
         return self.lazy().filter(func).collect()
 
     def groupby(self, func: Callable[[T], str]) -> Arr[tuple[str, list[T]]]:

--- a/iterpy/iter.py
+++ b/iterpy/iter.py
@@ -94,8 +94,8 @@ class Iter(Generic[T]):
         with multiprocessing.Pool() as pool:
             return Iter(pool.map(func, self._iterator))
 
-    def filter(self, func: Callable[[T], bool]) -> Iter[T]:
-        return Iter(filter(func, self._iterator))  # type: ignore
+    def filter(self, func: Callable[[T], object]) -> Iter[T]:
+        return Iter(filter(func, self._iterator))
 
     def groupby(self, func: Callable[[T], str]) -> Iter[tuple[str, list[T]]]:
         groups_with_values: defaultdict[str, list[T]] = defaultdict(list)

--- a/iterpy/test_arr.py
+++ b/iterpy/test_arr.py
@@ -45,6 +45,26 @@ def test_filter():
     assert result == [2]
 
 
+class Truthy:
+    def __init__(self, value: bool) -> None:
+        self._value = value
+
+    def __bool__(self) -> bool:
+        return self._value
+
+
+def test_filter_with_custom_bool_predicate():
+    iterator = Arr([1, 2])
+    result: list[int] = iterator.filter(lambda x: Truthy(x % 2 == 0)).to_list()
+    assert result == [2]
+
+
+def test_filter_with_len_based_truthiness_predicate():
+    iterator = Arr([1, 2])
+    result: list[int] = iterator.filter(lambda x: [x] if x % 2 == 0 else []).to_list()
+    assert result == [2]
+
+
 def test_reduce():
     iterator = Arr([1, 2])
     result: int = iterator.reduce(lambda x, y: x + y)

--- a/iterpy/test_iter.py
+++ b/iterpy/test_iter.py
@@ -45,6 +45,26 @@ def test_filter():
     assert result == [2]
 
 
+class Truthy:
+    def __init__(self, value: bool) -> None:
+        self._value = value
+
+    def __bool__(self) -> bool:
+        return self._value
+
+
+def test_filter_with_custom_bool_predicate():
+    iterator = Iter([1, 2])
+    result: list[int] = iterator.filter(lambda x: Truthy(x % 2 == 0)).to_list()
+    assert result == [2]
+
+
+def test_filter_with_len_based_truthiness_predicate():
+    iterator = Iter([1, 2])
+    result: list[int] = iterator.filter(lambda x: [x] if x % 2 == 0 else []).to_list()
+    assert result == [2]
+
+
 def test_reduce():
     iterator = Iter([1, 2])
     result: int = iterator.reduce(lambda x, y: x + y)


### PR DESCRIPTION
Widens `Iter.filter` / `Arr.filter` predicates from `Callable[[T], bool]` to `Callable[[T], object]`.